### PR TITLE
nestしたプロパティを扱えるようにした

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ const { SequelizeDriver } = require('clay-driver-sequelize')
 API
 ---------
 
-# clay-driver-sequelize@3.0.0
+# clay-driver-sequelize@3.0.2
 
 Clay driver for Sequelize
 

--- a/doc/api/api.md
+++ b/doc/api/api.md
@@ -1,4 +1,4 @@
-# clay-driver-sequelize@3.0.1
+# clay-driver-sequelize@3.0.2
 
 Clay driver for Sequelize
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 /**
  * Clay driver for Sequelize
  * @module clay-driver-sequelize
- * @version 3.0.1
+ * @version 3.0.2
  */
 
 'use strict'

--- a/lib/modeling/define_models.js
+++ b/lib/modeling/define_models.js
@@ -9,7 +9,10 @@
 const Sequelize = require('sequelize')
 const co = require('co')
 const { STRING } = Sequelize
+const { DataTypes } = require('clay-constants')
 const { typeOf, withType } = require('clay-serial')
+const { OBJECT } = DataTypes
+const { expand } = require('objnest')
 
 const parseValue = (value) => String(value)
 
@@ -78,9 +81,10 @@ function defineModels (db) {
     instanceMethods: {
       asClay () {
         const s = this
-        return s.EntityAttributes.reduce((attributes, entityAttribute) => Object.assign(attributes, {
+        let values = s.EntityAttributes.reduce((attributes, entityAttribute) => Object.assign(attributes, {
           [entityAttribute.name]: entityAttribute.toValue()
         }), { id: s.cid })
+        return expand(values)
       }
     },
     classMethods: {
@@ -183,16 +187,26 @@ function defineModels (db) {
     classMethods: {
       setAttributeValues (entity, values) {
         const { id: EntityId } = entity
+        // TODO make it parallel for better performance
         return co(function * () {
           for (let name of Object.keys(values)) {
             let value = values[ name ]
+            let type = typeOf(value)
+            // TODO Array support
+            if (type === OBJECT) {
+              let subValues = Object.keys(value)
+                .reduce((subValues, subKey) => Object.assign(subValues, {
+                  [`${name}.${subKey}`]: value[ subKey ]
+                }), {})
+              yield EntityAttribute.setAttributeValues(entity, subValues)
+              continue
+            }
             let [ entityAttribute ] = yield EntityAttribute.findOrCreate({
               where: { EntityId, name },
               defaults: { EntityId, name }
             })
-            // TODO Json support
             yield entityAttribute.update({
-              type: typeOf(value),
+              type,
               value: parseValue(value)
             })
           }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "clay-serial": "^2.0.2",
     "co": "^4.6.0",
     "continuation-local-storage": "^3.2.0",
+    "objnest": "^3.0.9",
     "sequelize": "^3.30.4"
   },
   "devDependencies": {
@@ -44,7 +45,7 @@
     "ape-tmpl": "^5.0.20",
     "ape-updating": "^4.1.0",
     "clay-driver-tests": "^2.0.1",
-    "clay-lump": "^4.0.1",
+    "clay-lump": "^4.1.1",
     "coz": "^6.0.20",
     "injectmock": "^2.0.0",
     "mkdirp": "^0.5.1",


### PR DESCRIPTION
検索とかもできるように、平たく変換して格納し、出すときにまたネストした形に戻すようにした

### 使うとき

```javascript
    let created = yield driver.create('Foo', {
      bar: {
        b: false,
        n: 1,
        s: 'hoge',
        d: new Date()
      }
    })
    equal(typeof created.bar.b, 'boolean')
    equal(typeof created.bar.n, 'number')
    equal(typeof created.bar.s, 'string')
    ok(created.bar.d instanceof Date)
```

### 実際の格納データ

```javascript
[
 { name: 'bar.b', type: 'clay:boolean', value: '1'},
 /* ... */
]
```