### PR TITLE
Remove 'update' dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,8 +38,7 @@
     "retry-as-promised": "^2.2.0",
     "sequelize": "^4.3.2",
     "sg-queue": "^1.1.4",
-    "stringcase": "^4.0.0",
-    "update": "^0.7.4"
+    "stringcase": "^4.0.0"
   },
   "devDependencies": {
     "ababel": "^2.0.1",


### PR DESCRIPTION
不要な dependency が混入していたので削除。

ちなみにこの `update` というモジュールはサイズがデカい。 `sequelize` と比較するとこれくらい。

|name|children|size|
|--------|-----|----|
|update                     | 1395         | 20.07M |
| sequelize                  | 25           | 13.88M |