### PR TITLE
updateの速度改善

### DIFF
--- a/doc/api/api.md
+++ b/doc/api/api.md
@@ -1,4 +1,4 @@
-# clay-driver-sequelize@6.0.4
+# clay-driver-sequelize@6.0.5
 
 Clay driver for Sequelize
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,7 @@
 /**
  * Clay driver for Sequelize
  * @module clay-driver-sequelize
- * @version 6.0.4
+ * @version 6.0.5
  */
 
 'use strict'

--- a/lib/modeling/entity_model.js
+++ b/lib/modeling/entity_model.js
@@ -14,6 +14,7 @@ const LRU = require('lru-cache')
 const {deserialize} = require('../helpers/serializer')
 const {pack, unpack} = require('msgpack')
 const {ENTITY_SUFFIX, OVERFLOW_SUFFIX, ID_SUFFIX} = require('../constants/model_keywords')
+const {clone} = require('asobj')
 
 const {DataTypes} = require('clay-constants')
 
@@ -154,6 +155,18 @@ function entityModel ({
           })
         )
         return {base, extra}
+      },
+      filterExtra (prevExtra, extra) {
+        const filteredExtra = clone(extra)
+        for (const key of Object.keys(extra)) {
+          const hasExtra = Boolean(extra[key])
+          const hasPrevExtra = Boolean(prevExtra[key])
+          const shouldIgnore = !hasExtra && !hasPrevExtra
+          if (shouldIgnore) {
+            delete filteredExtra[key]
+          }
+        }
+        return filteredExtra
       },
       async forList (attributes, {offset, limit, filter, sort} = {}) {
         const s = this

--- a/lib/sequelize_driver.js
+++ b/lib/sequelize_driver.js
@@ -162,12 +162,21 @@ class SequelizeDriver extends Driver {
     if (!entity) {
       throw new Error(`Entity not found for ${id}`)
     }
+
+    const prevAttributes = entity.asClay(entityAttributes)
+    delete prevAttributes.id
+    const prevCols = await Attribute.colsFor(prevAttributes)
+    const {extra: prevExtraValues} = Entity.valuesWithCols(prevCols)
+
     Entity.forOneCache.del(Entity.cacheKeyFor(cid))
     delete attributes.id
     const cols = await Attribute.colsFor(attributes)
     const {base: baseValues, extra: extraValues} = Entity.valuesWithCols(cols)
+
+    const filteredExtraValues = Entity.filterExtra(prevExtraValues, extraValues)
+
     await entity.update(baseValues)
-    await entity.updateExtra(extraValues)
+    await entity.updateExtra(filteredExtraValues)
     Entity.forOneCache.del(Entity.cacheKeyFor(cid))
     await asleep(1)
     return s.one(resourceName, entity.cid)


### PR DESCRIPTION
Extra テーブルの更新において key = null となる場合にもクエリを発行していたため、update メソッドを実行すると attributes の数だけ Extra.upsert() が走っていた。

無駄な Extra.upsert() を減らすために、更新の必要ない extraValues をフィルタリングした。

結果。だいたい create と同じ速度になった。

```
Took 7811ms for 50 entities, 10 attributes to create
Took 7447ms for 50 entities, 10 attributes to update
```